### PR TITLE
Track line and column of tokens in tokenizer

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -88,20 +88,21 @@ fn eat<'a>(source: &'a str, pattern: &Regex) -> (&'a str, Option<&'a str>) {
 fn get_new_position<'a>(eaten_str: &'a str, current_line: usize, current_column: usize) -> (usize, usize) {
     let lines_eaten = eaten_str.matches("\n").count();
 
-    // If there was a newline we're on a totally different column
     let column = if lines_eaten > 0 {
-        // If there's some characters after the newline, count them!
+        // If there was a newline we're on a totally different column
+
         if let Some(captures) = PATTERN_CHARS_AFTER_NEWLINE.captures(eaten_str) {
+            // If there's some characters after the newline, count them!
             // Add 1 so we start at a column of 1
             captures.get(1).unwrap().as_str().len() + 1
         }
-        // Otherwise, just restart at 1.
         else {
+            // Otherwise, just restart at 1.
             1
         }
     }
-    // Otherwise we can just increment the current column by the length of the eaten chars
     else {
+        // Otherwise we can just increment the current column by the length of the eaten chars
         current_column + eaten_str.len()
     };
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -124,6 +124,9 @@ pub fn tokenize<'a>(source: &'a str) -> Result<Vec<Token<'a>>, TokenizeError<'a>
                     column: current_column,
                 });
 
+                // This will cause problems if tokens match more than one line,
+                // but that seems really really unlikely - that would mean
+                // allowing whitespace in the tokens!
                 current_column += eaten_str.len();
             }
             None => break,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -113,8 +113,8 @@ fn get_new_position<'a>(eaten_str: &'a str, current_line: usize, current_column:
 pub fn tokenize<'a>(source: &'a str) -> Result<Vec<Token<'a>>, TokenizeError<'a>> {
     let mut tokens = Vec::new();
     let mut current = source;
-    let mut current_line: usize = 1;
-    let mut current_column: usize = 1;
+    let mut current_line = 1;
+    let mut current_column = 1;
 
     loop {
         let (next_current, matched_whitespace) = eat(current, &PATTERN_WHITESPACE);


### PR DESCRIPTION
Wanted to have this here, since it's probably going to be important for sane parser errors! This will track the line and column that each token *starts* on in `usize` fields. There is a test case for this behavior.

~~This code works under the assumption that tokens are a single line. **This will break for multi-line string literals**, should we choose to parse them in the tokenizer.~~

This will cause issues with column counts when the source code contains UTF-8 characters - we'd need another crate to handle that (specifically getting the length, in grapheme clusters, of a UTF-8 string).