### PR TITLE
Parse function declarations

### DIFF
--- a/parse_examples/should_not_parse/bad_function_declaration.lua
+++ b/parse_examples/should_not_parse/bad_function_declaration.lua
@@ -1,0 +1,2 @@
+local function bad
+end

--- a/parse_examples/should_parse/function_declaration.lua
+++ b/parse_examples/should_parse/function_declaration.lua
@@ -1,0 +1,7 @@
+local function test(a, b, c)
+	print(a, b, c)
+end
+
+function globalTest(a, b, c)
+	print(a, b, c)
+end

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -82,6 +82,7 @@ pub enum Statement<'a> {
     NumericFor(NumericFor<'a>),
     WhileLoop(WhileLoop<'a>),
     RepeatLoop(RepeatLoop<'a>),
+    FunctionDeclaration(FunctionDeclaration<'a>),
 }
 
 // chunk ::= block

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -38,6 +38,14 @@ pub struct RepeatLoop<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct FunctionDeclaration<'a> {
+    pub name: &'a str,
+    pub body: Chunk<'a>,
+    pub parameters: Vec<&'a str>,
+    pub local: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum Expression<'a> {
     Nil,
     Bool(bool),

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -18,6 +18,7 @@ fn emit_statement<'a>(w: &mut Write, statement: &Statement<'a>) -> fmt::Result {
         &Statement::NumericFor(ref value) => emit_numeric_for(w, value)?,
         &Statement::WhileLoop(ref value) => emit_while_loop(w, value)?,
         &Statement::RepeatLoop(ref value) => emit_repeat_loop(w, value)?,
+        unknown => panic!("Unknown statement: {:?}", unknown),
     }
 
     Ok(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -204,6 +204,29 @@ define_parser!(ParseRepeatLoop, RepeatLoop<'state>, |_, state| {
     }))
 });
 
+struct ParseFunctionDeclaration;
+define_parser!(ParseFunctionDeclaration, FunctionDeclaration<'state>, |_, state| {
+    let local = match ParseKeyword("local").parse(state) {
+        Ok(_) => true,
+        _ => false,
+    };
+
+    let (state, _) = ParseKeyword("function").parse(state)?;
+    let (state, name) = ParseIdentifier.parse(state)?;
+    let (state, _) = ParseToken { kind: TokenKind::OpenParen }.parse(state)?;
+    let (state, parameters) = ZeroOrMore(ParseIdentifier).parse(state)?;
+    let (state, _) = ParseToken { kind: TokenKind::CloseParen }.parse(state)?;
+    let (state, body) = ParseChunk.parse(state)?;
+    let (state, _) = ParseKeyword("end").parse(state)?;
+
+    Ok((state, FunctionDeclaration {
+        local,
+        name,
+        parameters,
+        body,
+    }))
+});
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,3 @@
-use std::borrow::Cow;
-use std::fmt;
-
 use tokenizer::{Token, TokenKind};
 use ast::*;
 use parser_core::*;
@@ -96,6 +93,7 @@ define_parser!(ParseStatement, Statement<'state>, |_, state| {
         ParseNumericFor => Statement::NumericFor,
         ParseWhileLoop => Statement::WhileLoop,
         ParseRepeatLoop => Statement::RepeatLoop,
+        ParseFunctionDeclaration => Statement::FunctionDeclaration,
     })
 });
 
@@ -116,7 +114,7 @@ define_parser!(ParseLocalAssignment, LocalAssignment<'state>, |_, state| {
 
     let (state, names) = DelimitedOneOrMore(ParseIdentifier, ParseOperator(",")).parse(state)?;
 
-    let (state, expressions) = match (ParseOperator("=").parse(state)) {
+    let (state, expressions) = match ParseOperator("=").parse(state) {
         Ok((state, _)) => DelimitedOneOrMore(ParseExpression, ParseOperator(",")).parse(state)?,
         Err(_) => (state, Vec::new()),
     };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,14 +22,12 @@ pub fn parse_from_tokens<'a>(tokens: &'a [Token<'a>]) -> Result<Chunk<'a>, Strin
     Ok(chunk)
 }
 
-struct ParseToken<'a> {
-    pub kind: TokenKind<'a>,
-}
+struct ParseToken<'a>(pub TokenKind<'a>);
 
 define_parser!(ParseToken<'state>, &'state Token<'state>, |this: &ParseToken<'state>, state: ParseState<'state>| {
     match state.peek() {
         Some(token) => {
-            if token.kind == this.kind {
+            if token.kind == this.0 {
                 Ok((state.advance(1), token))
             } else {
                 Err(ParseAbort::NoMatch)
@@ -57,14 +55,14 @@ define_parser!(ParseIdentifier, &'state str, |_, state: ParseState<'state>| {
 
 struct ParseKeyword(pub &'static str);
 define_parser!(ParseKeyword, (), |this: &ParseKeyword, state: ParseState<'state>| {
-    let (state, _) = ParseToken { kind: TokenKind::Keyword(this.0) }.parse(state)?;
+    let (state, _) = ParseToken(TokenKind::Keyword(this.0)).parse(state)?;
 
     Ok((state, ()))
 });
 
 struct ParseOperator(pub &'static str);
 define_parser!(ParseOperator, (), |this: &ParseOperator, state: ParseState<'state>| {
-    let (state, _) = ParseToken { kind: TokenKind::Operator(this.0) }.parse(state)?;
+    let (state, _) = ParseToken(TokenKind::Operator(this.0)).parse(state)?;
 
     Ok((state, ()))
 });
@@ -135,9 +133,9 @@ define_parser!(ParseLocalAssignment, LocalAssignment<'state>, |_, state| {
 struct ParseFunctionCall;
 define_parser!(ParseFunctionCall, FunctionCall<'state>, |_, state| {
     let (state, name) = ParseIdentifier.parse(state)?;
-    let (state, _) = ParseToken { kind: TokenKind::OpenParen }.parse(state)?;
+    let (state, _) = ParseToken(TokenKind::OpenParen).parse(state)?;
     let (state, expressions) = DelimitedZeroOrMore(ParseExpression, ParseOperator(",")).parse(state)?;
-    let (state, _) = ParseToken { kind: TokenKind::CloseParen }.parse(state)?;
+    let (state, _) = ParseToken(TokenKind::CloseParen).parse(state)?;
 
     Ok((state, FunctionCall {
         name_expression: Box::new(Expression::Name(name)),
@@ -213,9 +211,9 @@ define_parser!(ParseFunctionDeclaration, FunctionDeclaration<'state>, |_, state|
 
     let (state, _) = ParseKeyword("function").parse(state)?;
     let (state, name) = ParseIdentifier.parse(state)?;
-    let (state, _) = ParseToken { kind: TokenKind::OpenParen }.parse(state)?;
+    let (state, _) = ParseToken(TokenKind::OpenParen).parse(state)?;
     let (state, parameters) = ZeroOrMore(ParseIdentifier).parse(state)?;
-    let (state, _) = ParseToken { kind: TokenKind::CloseParen }.parse(state)?;
+    let (state, _) = ParseToken(TokenKind::CloseParen).parse(state)?;
     let (state, body) = ParseChunk.parse(state)?;
     let (state, _) = ParseKeyword("end").parse(state)?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -204,9 +204,8 @@ define_parser!(ParseRepeatLoop, RepeatLoop<'state>, |_, state| {
 
 struct ParseFunctionDeclaration;
 define_parser!(ParseFunctionDeclaration, FunctionDeclaration<'state>, |_, state| {
-    let (state, local) = ParseKeyword("local").parse(state)
-        .map(|(new_state, _)| (new_state, true))
-        .unwrap_or((state, false));
+    let (state, local) = Optional(ParseKeyword("local")).parse(state)
+        .map(|(state, value)| (state, value.is_some()))?;
 
     let (state, _) = ParseKeyword("function").parse(state)?;
     let (state, name) = ParseIdentifier.parse(state)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -301,7 +301,7 @@ mod test {
                     ]
                 })
             },
-            _ => panic!("Incorrect statement kind {:?}, statement")
+            _ => panic!("Incorrect statement kind {:?}", statement)
         };
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -204,10 +204,9 @@ define_parser!(ParseRepeatLoop, RepeatLoop<'state>, |_, state| {
 
 struct ParseFunctionDeclaration;
 define_parser!(ParseFunctionDeclaration, FunctionDeclaration<'state>, |_, state| {
-    let (state, local) = match ParseKeyword("local").parse(state) {
-        Ok((new_state, _)) => (new_state, true),
-        _ => (state, false)
-    };
+    let (state, local) = ParseKeyword("local").parse(state)
+        .map(|(new_state, _)| (new_state, true))
+        .unwrap_or((state, false));
 
     let (state, _) = ParseKeyword("function").parse(state)?;
     let (state, name) = ParseIdentifier.parse(state)?;

--- a/src/parser_core.rs
+++ b/src/parser_core.rs
@@ -1,4 +1,4 @@
-use tokenizer::{Token, TokenKind};
+use tokenizer::Token;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParseAbort {

--- a/src/parser_core.rs
+++ b/src/parser_core.rs
@@ -8,6 +8,7 @@ pub enum ParseAbort {
 
     /// Indicates that the parser was unable to match the input and hit the
     /// error described by the returned string.
+    #[allow(dead_code)]
     Error(String)
 }
 

--- a/src/parser_core.rs
+++ b/src/parser_core.rs
@@ -175,3 +175,21 @@ impl<'a, ItemParser: Parser<'a>, DelimiterParser: Parser<'a>> Parser<'a> for Del
         Ok((state, values))
     }
 }
+
+pub struct Optional<InnerParser>(pub InnerParser);
+
+impl<'a, ItemParser: Parser<'a>> Parser<'a> for Optional<ItemParser> {
+    type Item = Option<ItemParser::Item>;
+
+    fn item_name(&self) -> String {
+        format!("optional {}", self.0.item_name())
+    }
+
+    fn parse(&self, state: ParseState<'a>) -> Result<(ParseState<'a>, Self::Item), ParseAbort> {
+        match self.0.parse(state) {
+            Ok((new_state, matched_value)) => Ok((new_state, Some(matched_value))),
+            Err(ParseAbort::NoMatch) => Ok((state, None)),
+            Err(ParseAbort::Error(message)) => Err(ParseAbort::Error(message)),
+        }
+    }
+}

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -71,7 +71,7 @@ struct TryAdvanceResult<'a> {
 
 lazy_static! {
     static ref KEYWORDS: HashSet<&'static str> = HashSet::from_iter(vec![
-        "local",
+        "local", "function",
         "while", "repeat", "until", "for",
         "do", "end",
     ]);


### PR DESCRIPTION
This has a mountain of other stuff tacked on.

* Added the ability to parse function declarations, `local` or not
* `ParseToken` is now a tuple struct, for better usability and ergonomics.
* `function` is now a keyword.
* We now have an `Optional` parser that will eat a token and return `(ParseState, Option<Item>)`
* Squashed some warnings