### PR TITLE
Simplify binary operation parsing

### DIFF
--- a/parse_examples/results/function_declaration_1.tokens.json
+++ b/parse_examples/results/function_declaration_1.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "function"
+      "Symbol": "Function"
     },
     "whitespace": "",
     "line": 1,
@@ -33,7 +33,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 2,

--- a/parse_examples/results/function_declaration_2.tokens.json
+++ b/parse_examples/results/function_declaration_2.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "function"
+      "Symbol": "Function"
     },
     "whitespace": "",
     "line": 1,
@@ -89,7 +89,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 3,

--- a/parse_examples/results/function_declaration_3.tokens.json
+++ b/parse_examples/results/function_declaration_3.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "local"
+      "Symbol": "Local"
     },
     "whitespace": "",
     "line": 1,
@@ -9,7 +9,7 @@
   },
   {
     "kind": {
-      "Keyword": "function"
+      "Symbol": "Function"
     },
     "whitespace": " ",
     "line": 1,
@@ -113,7 +113,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 3,

--- a/parse_examples/results/if_statement_1.tokens.json
+++ b/parse_examples/results/if_statement_1.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "if"
+      "Symbol": "If"
     },
     "whitespace": "",
     "line": 1,
@@ -17,7 +17,7 @@
   },
   {
     "kind": {
-      "Keyword": "then"
+      "Symbol": "Then"
     },
     "whitespace": " ",
     "line": 1,
@@ -57,7 +57,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 3,

--- a/parse_examples/results/if_statement_2.tokens.json
+++ b/parse_examples/results/if_statement_2.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "if"
+      "Symbol": "If"
     },
     "whitespace": "",
     "line": 1,
@@ -17,7 +17,7 @@
   },
   {
     "kind": {
-      "Keyword": "then"
+      "Symbol": "Then"
     },
     "whitespace": " ",
     "line": 1,
@@ -57,7 +57,7 @@
   },
   {
     "kind": {
-      "Keyword": "else"
+      "Symbol": "Else"
     },
     "whitespace": "\n",
     "line": 3,
@@ -97,7 +97,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 5,

--- a/parse_examples/results/if_statement_3.tokens.json
+++ b/parse_examples/results/if_statement_3.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "if"
+      "Symbol": "If"
     },
     "whitespace": "",
     "line": 1,
@@ -17,7 +17,7 @@
   },
   {
     "kind": {
-      "Keyword": "then"
+      "Symbol": "Then"
     },
     "whitespace": " ",
     "line": 1,
@@ -57,7 +57,7 @@
   },
   {
     "kind": {
-      "Keyword": "elseif"
+      "Symbol": "ElseIf"
     },
     "whitespace": "\n",
     "line": 3,
@@ -73,7 +73,7 @@
   },
   {
     "kind": {
-      "Keyword": "then"
+      "Symbol": "Then"
     },
     "whitespace": " ",
     "line": 3,
@@ -113,7 +113,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 5,

--- a/parse_examples/results/if_statement_4.tokens.json
+++ b/parse_examples/results/if_statement_4.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "if"
+      "Symbol": "If"
     },
     "whitespace": "",
     "line": 1,
@@ -17,7 +17,7 @@
   },
   {
     "kind": {
-      "Keyword": "then"
+      "Symbol": "Then"
     },
     "whitespace": " ",
     "line": 1,
@@ -57,7 +57,7 @@
   },
   {
     "kind": {
-      "Keyword": "elseif"
+      "Symbol": "ElseIf"
     },
     "whitespace": "\n",
     "line": 3,
@@ -73,7 +73,7 @@
   },
   {
     "kind": {
-      "Keyword": "then"
+      "Symbol": "Then"
     },
     "whitespace": " ",
     "line": 3,
@@ -113,7 +113,7 @@
   },
   {
     "kind": {
-      "Keyword": "elseif"
+      "Symbol": "ElseIf"
     },
     "whitespace": "\n",
     "line": 5,
@@ -129,7 +129,7 @@
   },
   {
     "kind": {
-      "Keyword": "then"
+      "Symbol": "Then"
     },
     "whitespace": " ",
     "line": 5,
@@ -169,7 +169,7 @@
   },
   {
     "kind": {
-      "Keyword": "else"
+      "Symbol": "Else"
     },
     "whitespace": "\n",
     "line": 7,
@@ -209,7 +209,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 9,

--- a/parse_examples/results/local_assignment_1.tokens.json
+++ b/parse_examples/results/local_assignment_1.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "local"
+      "Symbol": "Local"
     },
     "whitespace": "",
     "line": 1,
@@ -33,7 +33,7 @@
   },
   {
     "kind": {
-      "Keyword": "local"
+      "Symbol": "Local"
     },
     "whitespace": "\n",
     "line": 2,

--- a/parse_examples/results/local_assignment_2.tokens.json
+++ b/parse_examples/results/local_assignment_2.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "local"
+      "Symbol": "Local"
     },
     "whitespace": "",
     "line": 1,

--- a/parse_examples/results/local_assignment_3.tokens.json
+++ b/parse_examples/results/local_assignment_3.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "local"
+      "Symbol": "Local"
     },
     "whitespace": "",
     "line": 1,

--- a/parse_examples/results/local_assignment_4.tokens.json
+++ b/parse_examples/results/local_assignment_4.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "local"
+      "Symbol": "Local"
     },
     "whitespace": "",
     "line": 1,

--- a/parse_examples/results/local_declare_1.tokens.json
+++ b/parse_examples/results/local_declare_1.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "local"
+      "Symbol": "Local"
     },
     "whitespace": "",
     "line": 1,

--- a/parse_examples/results/local_declare_2.tokens.json
+++ b/parse_examples/results/local_declare_2.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "local"
+      "Symbol": "Local"
     },
     "whitespace": "",
     "line": 1,

--- a/parse_examples/results/numeric_for_loop_1.tokens.json
+++ b/parse_examples/results/numeric_for_loop_1.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "for"
+      "Symbol": "For"
     },
     "whitespace": "",
     "line": 1,
@@ -49,7 +49,7 @@
   },
   {
     "kind": {
-      "Keyword": "do"
+      "Symbol": "Do"
     },
     "whitespace": " ",
     "line": 1,
@@ -57,7 +57,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 2,

--- a/parse_examples/results/numeric_for_loop_2.tokens.json
+++ b/parse_examples/results/numeric_for_loop_2.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "for"
+      "Symbol": "For"
     },
     "whitespace": "",
     "line": 1,
@@ -65,7 +65,7 @@
   },
   {
     "kind": {
-      "Keyword": "do"
+      "Symbol": "Do"
     },
     "whitespace": " ",
     "line": 1,
@@ -105,7 +105,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 3,

--- a/parse_examples/results/numeric_for_loop_3.tokens.json
+++ b/parse_examples/results/numeric_for_loop_3.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "for"
+      "Symbol": "For"
     },
     "whitespace": "",
     "line": 1,
@@ -65,7 +65,7 @@
   },
   {
     "kind": {
-      "Keyword": "do"
+      "Symbol": "Do"
     },
     "whitespace": " ",
     "line": 1,
@@ -105,7 +105,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 3,

--- a/parse_examples/results/numeric_for_loop_4.tokens.json
+++ b/parse_examples/results/numeric_for_loop_4.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "for"
+      "Symbol": "For"
     },
     "whitespace": "",
     "line": 1,
@@ -65,7 +65,7 @@
   },
   {
     "kind": {
-      "Keyword": "do"
+      "Symbol": "Do"
     },
     "whitespace": " ",
     "line": 1,
@@ -73,7 +73,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": " ",
     "line": 1,

--- a/parse_examples/results/repeat_loop.tokens.json
+++ b/parse_examples/results/repeat_loop.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "repeat"
+      "Symbol": "Repeat"
     },
     "whitespace": "",
     "line": 1,
@@ -41,7 +41,7 @@
   },
   {
     "kind": {
-      "Keyword": "until"
+      "Symbol": "Until"
     },
     "whitespace": "\n",
     "line": 3,

--- a/parse_examples/results/tables.tokens.json
+++ b/parse_examples/results/tables.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "local"
+      "Symbol": "Local"
     },
     "whitespace": "",
     "line": 1,

--- a/parse_examples/results/unary_boolean_not.tokens.json
+++ b/parse_examples/results/unary_boolean_not.tokens.json
@@ -17,7 +17,7 @@
   },
   {
     "kind": {
-      "Keyword": "not"
+      "Symbol": "Not"
     },
     "whitespace": "",
     "line": 1,

--- a/parse_examples/results/while_loop.tokens.json
+++ b/parse_examples/results/while_loop.tokens.json
@@ -1,7 +1,7 @@
 [
   {
     "kind": {
-      "Keyword": "while"
+      "Symbol": "While"
     },
     "whitespace": "",
     "line": 1,
@@ -17,7 +17,7 @@
   },
   {
     "kind": {
-      "Keyword": "do"
+      "Symbol": "Do"
     },
     "whitespace": " ",
     "line": 1,
@@ -57,7 +57,7 @@
   },
   {
     "kind": {
-      "Keyword": "end"
+      "Symbol": "End"
     },
     "whitespace": "\n",
     "line": 3,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -7,7 +7,7 @@ pub enum UnaryOpKind {
     Length, // #
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum BinaryOpKind {
     Add, // +
     Subtract, // -

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -128,22 +128,16 @@ impl<'state> Parser<'state> for ParseBinaryOp {
     type Item = BinaryOpKind;
 
     fn parse(&self, state: ParseState<'state>) -> Result<(ParseState<'state>, Self::Item), ParseAbort> {
-        if let Some(token) = state.peek() {
-            match token.kind {
-                // Binary operations are always symbols
-                TokenKind::Symbol(symbol) => {
-                    // TokenKind doesn't derive Hash, so we use the string version
-                    if let Some(kind) = BINARY_OPS.get(symbol.to_str()) {
-                        // We must clone the kind here.
-                        // We can't simply defererence it, because we can't move out of the borrow.
-                        // We also can't just return the reference, because we need an actual value.
-                        Ok((state.advance(1), kind.clone()))
-                    }
-                    else {
-                        Err(ParseAbort::NoMatch)
-                    }
-                },
-                _ => Err(ParseAbort::NoMatch)
+        if let Some(Token { kind: TokenKind::Symbol(symbol), .. }) = state.peek() {
+            // TokenKind doesn't derive Hash, so we use the string version
+            if let Some(kind) = BINARY_OPS.get(symbol.to_str()) {
+                // We must clone the kind here.
+                // We can't simply defererence it, because we can't move out of the borrow.
+                // We also can't just return the reference, because we need an actual value.
+                Ok((state.advance(1), kind.clone()))
+            }
+            else {
+                Err(ParseAbort::NoMatch)
             }
         }
         else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -107,31 +107,20 @@ define_parser!(ParseUnaryOp, UnaryOpKind, |_, state| {
     }
 });
 
-lazy_static! {
-    static ref BINARY_OPS: HashMap<Symbol, BinaryOpKind> = {
-        let mut map = HashMap::new();
-
-        map.insert(Symbol::Plus, BinaryOpKind::Add);
-        map.insert(Symbol::Minus, BinaryOpKind::Subtract);
-        map.insert(Symbol::Star, BinaryOpKind::Multiply);
-        map.insert(Symbol::Slash, BinaryOpKind::Divide);
-        map.insert(Symbol::Caret, BinaryOpKind::Exponent);
-        map.insert(Symbol::TwoDots, BinaryOpKind::Concat);
-
-        map
-    };
-}
-
 struct ParseBinaryOp;
 define_parser!(ParseBinaryOp, BinaryOpKind, |_, state: ParseState<'state>| {
     if let Some(&Token { kind: TokenKind::Symbol(symbol), .. }) = state.peek() {
-        // TokenKind doesn't derive Hash, so we use the string version
-        if let Some(kind) = BINARY_OPS.get(&symbol) {
-            Ok((state.advance(1), *kind))
-        }
-        else {
-            Err(ParseAbort::NoMatch)
-        }
+        let kind = match symbol {
+            Symbol::Plus => BinaryOpKind::Add,
+            Symbol::Minus => BinaryOpKind::Subtract,
+            Symbol::Star => BinaryOpKind::Multiply,
+            Symbol::Slash => BinaryOpKind::Divide,
+            Symbol::Caret => BinaryOpKind::Exponent,
+            Symbol::TwoDots => BinaryOpKind::Concat,
+            _ => return Err(ParseAbort::NoMatch)
+        };
+
+        Ok((state.advance(1), kind))
     }
     else {
         Err(ParseAbort::NoMatch)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -124,9 +124,9 @@ lazy_static! {
 
 struct ParseBinaryOp;
 define_parser!(ParseBinaryOp, BinaryOpKind, |_, state: ParseState<'state>| {
-    if let Some(Token { kind: TokenKind::Symbol(symbol), .. }) = state.peek() {
+    if let Some(&Token { kind: TokenKind::Symbol(symbol), .. }) = state.peek() {
         // TokenKind doesn't derive Hash, so we use the string version
-        if let Some(kind) = BINARY_OPS.get(symbol) {
+        if let Some(kind) = BINARY_OPS.get(&symbol) {
             Ok((state.advance(1), *kind))
         }
         else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 
 use tokenizer::{Token, TokenKind, Symbol};
 use ast::*;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -26,6 +26,8 @@ pub enum Symbol {
     Comma,
     Semicolon,
     Ellipse,
+    And,
+    Or
 }
 
 impl Symbol {
@@ -48,6 +50,8 @@ impl Symbol {
             Symbol::Comma => ",",
             Symbol::Semicolon => ";",
             Symbol::Ellipse => "...",
+            Symbol::And => "and",
+            Symbol::Or => "or",
         }
     }
 }
@@ -71,8 +75,6 @@ pub enum Keyword {
     False,
     Nil,
     Not,
-    And,
-    Or,
 }
 
 impl Keyword {
@@ -94,8 +96,6 @@ impl Keyword {
             Keyword::False => "false",
             Keyword::Nil => "nil",
             Keyword::Not => "not",
-            Keyword::And => "and",
-            Keyword::Or => "or",
         }
     }
 }
@@ -168,7 +168,7 @@ lazy_static! {
         Keyword::If, Keyword::While, Keyword::Repeat, Keyword::Until, Keyword::For,
         Keyword::Then, Keyword::Do, Keyword::Else, Keyword::ElseIf, Keyword::End,
         Keyword::True, Keyword::False, Keyword::Nil,
-        Keyword::Not, Keyword::And, Keyword::Or,
+        Keyword::Not,
     ];
 
     static ref OPERATORS: Vec<Symbol> = vec![
@@ -177,6 +177,7 @@ lazy_static! {
         Symbol::LeftParen, Symbol::RightParen,
 
         Symbol::Plus, Symbol::Minus, Symbol::Star, Symbol::Slash, Symbol::Caret, Symbol::TwoDots,
+        Symbol::And, Symbol::Or,
         Symbol::Hash,
         Symbol::Equal,
         Symbol::Comma, Symbol::Semicolon,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use regex::{self, Regex};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Symbol {
     LeftBrace,
     RightBrace,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -324,11 +324,11 @@ mod tests {
 
     #[test]
     fn keyword_vs_identifier() {
-        test_kinds_eq("local", vec![TokenKind::Keyword(Keyword::Local)]);
+        test_kinds_eq("local", vec![TokenKind::Symbol(Symbol::Local)]);
         test_kinds_eq("local_", vec![TokenKind::Identifier("local_".into())]);
         test_kinds_eq("locale", vec![TokenKind::Identifier("locale".into())]);
         test_kinds_eq("_local", vec![TokenKind::Identifier("_local".into())]);
-        test_kinds_eq("local _", vec![TokenKind::Keyword(Keyword::Local), TokenKind::Identifier("_".into())]);
+        test_kinds_eq("local _", vec![TokenKind::Symbol(Symbol::Local), TokenKind::Identifier("_".into())]);
     }
 
     #[test]
@@ -379,7 +379,7 @@ mod tests {
         let tokenized = tokenize(input).unwrap();
         assert_eq!(tokenized, vec![
             Token {
-                kind: TokenKind::Keyword(Keyword::Local),
+                kind: TokenKind::Symbol(Symbol::Local),
                 whitespace: "".into(),
                 line: 1,
                 column: 1,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use regex::{self, Regex};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Symbol {
     LeftBrace,
     RightBrace,


### PR DESCRIPTION
Two changes:

* Binary operations are now parsed using a map
* Keywords are now Symbols. Tests have been altered to match. `ParseKeyword` no longer exists.

I've also removed the pre-JSON era test cases in the tokenizer.