### PR TITLE
Miscellaneous parsing features

### DIFF
--- a/parse_examples/results/boolean_literal.ast.json
+++ b/parse_examples/results/boolean_literal.ast.json
@@ -1,0 +1,28 @@
+{
+  "statements": [
+    {
+      "LocalAssignment": {
+        "names": [
+          "a"
+        ],
+        "values": [
+          {
+            "Bool": true
+          }
+        ]
+      }
+    },
+    {
+      "LocalAssignment": {
+        "names": [
+          "b"
+        ],
+        "values": [
+          {
+            "Bool": false
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/parse_examples/results/boolean_literal.tokens.json
+++ b/parse_examples/results/boolean_literal.tokens.json
@@ -1,0 +1,130 @@
+[
+  {
+    "kind": {
+      "Symbol": "Local"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 0,
+      "line": 1,
+      "column": 1
+    },
+    "end_position": {
+      "bytes": 5,
+      "line": 1,
+      "column": 6
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "a"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 6,
+      "line": 1,
+      "column": 7
+    },
+    "end_position": {
+      "bytes": 7,
+      "line": 1,
+      "column": 8
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Equal"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 8,
+      "line": 1,
+      "column": 9
+    },
+    "end_position": {
+      "bytes": 9,
+      "line": 1,
+      "column": 10
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "True"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 10,
+      "line": 1,
+      "column": 11
+    },
+    "end_position": {
+      "bytes": 14,
+      "line": 1,
+      "column": 15
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Local"
+    },
+    "whitespace": "\n",
+    "start_position": {
+      "bytes": 15,
+      "line": 2,
+      "column": 0
+    },
+    "end_position": {
+      "bytes": 20,
+      "line": 2,
+      "column": 5
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "b"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 21,
+      "line": 2,
+      "column": 6
+    },
+    "end_position": {
+      "bytes": 22,
+      "line": 2,
+      "column": 7
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Equal"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 23,
+      "line": 2,
+      "column": 8
+    },
+    "end_position": {
+      "bytes": 24,
+      "line": 2,
+      "column": 9
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "False"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 25,
+      "line": 2,
+      "column": 10
+    },
+    "end_position": {
+      "bytes": 30,
+      "line": 2,
+      "column": 15
+    }
+  }
+]

--- a/parse_examples/results/generic_for_loop_1.ast.json
+++ b/parse_examples/results/generic_for_loop_1.ast.json
@@ -5,14 +5,16 @@
         "vars": [
           "i"
         ],
-        "iterator": {
-          "FunctionCall": {
-            "name_expression": {
-              "Name": "pairs"
-            },
-            "arguments": []
+        "item_source": [
+          {
+            "FunctionCall": {
+              "name_expression": {
+                "Name": "pairs"
+              },
+              "arguments": []
+            }
           }
-        },
+        ],
         "body": {
           "statements": []
         }

--- a/parse_examples/results/generic_for_loop_1.ast.json
+++ b/parse_examples/results/generic_for_loop_1.ast.json
@@ -1,0 +1,22 @@
+{
+  "statements": [
+    {
+      "GenericFor": {
+        "vars": [
+          "i"
+        ],
+        "iterator": {
+          "FunctionCall": {
+            "name_expression": {
+              "Name": "pairs"
+            },
+            "arguments": []
+          }
+        },
+        "body": {
+          "statements": []
+        }
+      }
+    }
+  ]
+}

--- a/parse_examples/results/generic_for_loop_1.tokens.json
+++ b/parse_examples/results/generic_for_loop_1.tokens.json
@@ -1,0 +1,130 @@
+[
+  {
+    "kind": {
+      "Symbol": "For"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 0,
+      "line": 1,
+      "column": 1
+    },
+    "end_position": {
+      "bytes": 3,
+      "line": 1,
+      "column": 4
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "i"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 4,
+      "line": 1,
+      "column": 5
+    },
+    "end_position": {
+      "bytes": 5,
+      "line": 1,
+      "column": 6
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "In"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 6,
+      "line": 1,
+      "column": 7
+    },
+    "end_position": {
+      "bytes": 8,
+      "line": 1,
+      "column": 9
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "pairs"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 9,
+      "line": 1,
+      "column": 10
+    },
+    "end_position": {
+      "bytes": 14,
+      "line": 1,
+      "column": 15
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "LeftParen"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 14,
+      "line": 1,
+      "column": 15
+    },
+    "end_position": {
+      "bytes": 15,
+      "line": 1,
+      "column": 16
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "RightParen"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 15,
+      "line": 1,
+      "column": 16
+    },
+    "end_position": {
+      "bytes": 16,
+      "line": 1,
+      "column": 17
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Do"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 17,
+      "line": 1,
+      "column": 18
+    },
+    "end_position": {
+      "bytes": 19,
+      "line": 1,
+      "column": 20
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "End"
+    },
+    "whitespace": "\n",
+    "start_position": {
+      "bytes": 20,
+      "line": 2,
+      "column": 0
+    },
+    "end_position": {
+      "bytes": 23,
+      "line": 2,
+      "column": 3
+    }
+  }
+]

--- a/parse_examples/results/generic_for_loop_2.ast.json
+++ b/parse_examples/results/generic_for_loop_2.ast.json
@@ -1,0 +1,43 @@
+{
+  "statements": [
+    {
+      "GenericFor": {
+        "vars": [
+          "i",
+          "v"
+        ],
+        "iterator": {
+          "FunctionCall": {
+            "name_expression": {
+              "Name": "pairs"
+            },
+            "arguments": [
+              {
+                "Name": "k"
+              }
+            ]
+          }
+        },
+        "body": {
+          "statements": [
+            {
+              "FunctionCall": {
+                "name_expression": {
+                  "Name": "print"
+                },
+                "arguments": [
+                  {
+                    "Name": "i"
+                  },
+                  {
+                    "Name": "v"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/parse_examples/results/generic_for_loop_2.tokens.json
+++ b/parse_examples/results/generic_for_loop_2.tokens.json
@@ -1,0 +1,274 @@
+[
+  {
+    "kind": {
+      "Symbol": "For"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 0,
+      "line": 1,
+      "column": 1
+    },
+    "end_position": {
+      "bytes": 3,
+      "line": 1,
+      "column": 4
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "i"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 4,
+      "line": 1,
+      "column": 5
+    },
+    "end_position": {
+      "bytes": 5,
+      "line": 1,
+      "column": 6
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Comma"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 5,
+      "line": 1,
+      "column": 6
+    },
+    "end_position": {
+      "bytes": 6,
+      "line": 1,
+      "column": 7
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "v"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 7,
+      "line": 1,
+      "column": 8
+    },
+    "end_position": {
+      "bytes": 8,
+      "line": 1,
+      "column": 9
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "In"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 9,
+      "line": 1,
+      "column": 10
+    },
+    "end_position": {
+      "bytes": 11,
+      "line": 1,
+      "column": 12
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "pairs"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 12,
+      "line": 1,
+      "column": 13
+    },
+    "end_position": {
+      "bytes": 17,
+      "line": 1,
+      "column": 18
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "LeftParen"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 17,
+      "line": 1,
+      "column": 18
+    },
+    "end_position": {
+      "bytes": 18,
+      "line": 1,
+      "column": 19
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "k"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 18,
+      "line": 1,
+      "column": 19
+    },
+    "end_position": {
+      "bytes": 19,
+      "line": 1,
+      "column": 20
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "RightParen"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 19,
+      "line": 1,
+      "column": 20
+    },
+    "end_position": {
+      "bytes": 20,
+      "line": 1,
+      "column": 21
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Do"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 21,
+      "line": 1,
+      "column": 22
+    },
+    "end_position": {
+      "bytes": 23,
+      "line": 1,
+      "column": 24
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "print"
+    },
+    "whitespace": "\n\t",
+    "start_position": {
+      "bytes": 25,
+      "line": 2,
+      "column": 2
+    },
+    "end_position": {
+      "bytes": 30,
+      "line": 2,
+      "column": 7
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "LeftParen"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 30,
+      "line": 2,
+      "column": 7
+    },
+    "end_position": {
+      "bytes": 31,
+      "line": 2,
+      "column": 8
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "i"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 31,
+      "line": 2,
+      "column": 8
+    },
+    "end_position": {
+      "bytes": 32,
+      "line": 2,
+      "column": 9
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Comma"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 32,
+      "line": 2,
+      "column": 9
+    },
+    "end_position": {
+      "bytes": 33,
+      "line": 2,
+      "column": 10
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "v"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 34,
+      "line": 2,
+      "column": 11
+    },
+    "end_position": {
+      "bytes": 35,
+      "line": 2,
+      "column": 12
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "RightParen"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 35,
+      "line": 2,
+      "column": 12
+    },
+    "end_position": {
+      "bytes": 36,
+      "line": 2,
+      "column": 13
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "End"
+    },
+    "whitespace": "\n",
+    "start_position": {
+      "bytes": 37,
+      "line": 3,
+      "column": 0
+    },
+    "end_position": {
+      "bytes": 40,
+      "line": 3,
+      "column": 3
+    }
+  }
+]

--- a/parse_examples/results/generic_for_loop_3.ast.json
+++ b/parse_examples/results/generic_for_loop_3.ast.json
@@ -8,16 +8,10 @@
         ],
         "item_source": [
           {
-            "FunctionCall": {
-              "name_expression": {
-                "Name": "pairs"
-              },
-              "arguments": [
-                {
-                  "Name": "k"
-                }
-              ]
-            }
+            "Name": "next"
+          },
+          {
+            "Name": "t"
           }
         ],
         "body": {

--- a/parse_examples/results/generic_for_loop_3.tokens.json
+++ b/parse_examples/results/generic_for_loop_3.tokens.json
@@ -1,0 +1,258 @@
+[
+  {
+    "kind": {
+      "Symbol": "For"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 0,
+      "line": 1,
+      "column": 1
+    },
+    "end_position": {
+      "bytes": 3,
+      "line": 1,
+      "column": 4
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "i"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 4,
+      "line": 1,
+      "column": 5
+    },
+    "end_position": {
+      "bytes": 5,
+      "line": 1,
+      "column": 6
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Comma"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 5,
+      "line": 1,
+      "column": 6
+    },
+    "end_position": {
+      "bytes": 6,
+      "line": 1,
+      "column": 7
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "v"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 7,
+      "line": 1,
+      "column": 8
+    },
+    "end_position": {
+      "bytes": 8,
+      "line": 1,
+      "column": 9
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "In"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 9,
+      "line": 1,
+      "column": 10
+    },
+    "end_position": {
+      "bytes": 11,
+      "line": 1,
+      "column": 12
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "next"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 12,
+      "line": 1,
+      "column": 13
+    },
+    "end_position": {
+      "bytes": 16,
+      "line": 1,
+      "column": 17
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Comma"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 16,
+      "line": 1,
+      "column": 17
+    },
+    "end_position": {
+      "bytes": 17,
+      "line": 1,
+      "column": 18
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "t"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 18,
+      "line": 1,
+      "column": 19
+    },
+    "end_position": {
+      "bytes": 19,
+      "line": 1,
+      "column": 20
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Do"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 20,
+      "line": 1,
+      "column": 21
+    },
+    "end_position": {
+      "bytes": 22,
+      "line": 1,
+      "column": 23
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "print"
+    },
+    "whitespace": "\n\t",
+    "start_position": {
+      "bytes": 24,
+      "line": 2,
+      "column": 2
+    },
+    "end_position": {
+      "bytes": 29,
+      "line": 2,
+      "column": 7
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "LeftParen"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 29,
+      "line": 2,
+      "column": 7
+    },
+    "end_position": {
+      "bytes": 30,
+      "line": 2,
+      "column": 8
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "i"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 30,
+      "line": 2,
+      "column": 8
+    },
+    "end_position": {
+      "bytes": 31,
+      "line": 2,
+      "column": 9
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Comma"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 31,
+      "line": 2,
+      "column": 9
+    },
+    "end_position": {
+      "bytes": 32,
+      "line": 2,
+      "column": 10
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "v"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 33,
+      "line": 2,
+      "column": 11
+    },
+    "end_position": {
+      "bytes": 34,
+      "line": 2,
+      "column": 12
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "RightParen"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 34,
+      "line": 2,
+      "column": 12
+    },
+    "end_position": {
+      "bytes": 35,
+      "line": 2,
+      "column": 13
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "End"
+    },
+    "whitespace": "\n",
+    "start_position": {
+      "bytes": 36,
+      "line": 3,
+      "column": 0
+    },
+    "end_position": {
+      "bytes": 39,
+      "line": 3,
+      "column": 3
+    }
+  }
+]

--- a/parse_examples/results/nil_literal.ast.json
+++ b/parse_examples/results/nil_literal.ast.json
@@ -1,0 +1,14 @@
+{
+  "statements": [
+    {
+      "LocalAssignment": {
+        "names": [
+          "a"
+        ],
+        "values": [
+          "Nil"
+        ]
+      }
+    }
+  ]
+}

--- a/parse_examples/results/nil_literal.tokens.json
+++ b/parse_examples/results/nil_literal.tokens.json
@@ -1,0 +1,66 @@
+[
+  {
+    "kind": {
+      "Symbol": "Local"
+    },
+    "whitespace": "",
+    "start_position": {
+      "bytes": 0,
+      "line": 1,
+      "column": 1
+    },
+    "end_position": {
+      "bytes": 5,
+      "line": 1,
+      "column": 6
+    }
+  },
+  {
+    "kind": {
+      "Identifier": "a"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 6,
+      "line": 1,
+      "column": 7
+    },
+    "end_position": {
+      "bytes": 7,
+      "line": 1,
+      "column": 8
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Equal"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 8,
+      "line": 1,
+      "column": 9
+    },
+    "end_position": {
+      "bytes": 9,
+      "line": 1,
+      "column": 10
+    }
+  },
+  {
+    "kind": {
+      "Symbol": "Nil"
+    },
+    "whitespace": " ",
+    "start_position": {
+      "bytes": 10,
+      "line": 1,
+      "column": 11
+    },
+    "end_position": {
+      "bytes": 13,
+      "line": 1,
+      "column": 14
+    }
+  }
+]

--- a/parse_examples/source/boolean_literal.lua
+++ b/parse_examples/source/boolean_literal.lua
@@ -1,0 +1,2 @@
+local a = true
+local b = false

--- a/parse_examples/source/generic_for_loop_1.lua
+++ b/parse_examples/source/generic_for_loop_1.lua
@@ -1,0 +1,2 @@
+for i in pairs() do
+end

--- a/parse_examples/source/generic_for_loop_2.lua
+++ b/parse_examples/source/generic_for_loop_2.lua
@@ -1,0 +1,3 @@
+for i, v in pairs(k) do
+	print(i, v)
+end

--- a/parse_examples/source/generic_for_loop_3.lua
+++ b/parse_examples/source/generic_for_loop_3.lua
@@ -1,0 +1,3 @@
+for i, v in next, t do
+	print(i, v)
+end

--- a/parse_examples/source/nil_literal.lua
+++ b/parse_examples/source/nil_literal.lua
@@ -1,0 +1,1 @@
+local a = nil

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -105,6 +105,14 @@ pub struct NumericFor<'a> {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GenericFor<'a> {
+    #[serde(borrow)]
+    pub vars: Vec<Cow<'a, str>>,
+    pub iterator: Expression<'a>,
+    pub body: Chunk<'a>
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IfStatement<'a> {
     #[serde(borrow)]
     pub condition: Expression<'a>,
@@ -190,6 +198,7 @@ pub enum Statement<'a> {
     LocalAssignment(LocalAssignment<'a>),
     FunctionCall(FunctionCall<'a>),
     NumericFor(NumericFor<'a>),
+    GenericFor(GenericFor<'a>),
     IfStatement(IfStatement<'a>),
     WhileLoop(WhileLoop<'a>),
     RepeatLoop(RepeatLoop<'a>),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -108,7 +108,7 @@ pub struct NumericFor<'a> {
 pub struct GenericFor<'a> {
     #[serde(borrow)]
     pub vars: Vec<Cow<'a, str>>,
-    pub iterator: Expression<'a>,
+    pub item_source: Vec<Expression<'a>>,
     pub body: Chunk<'a>
 }
 

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -16,6 +16,7 @@ fn emit_statement<'a>(w: &mut Write, statement: &Statement<'a>) -> fmt::Result {
         &Statement::LocalAssignment(ref value) => emit_local_assignment(w, value)?,
         &Statement::FunctionCall(ref value) => emit_function_call(w, value)?,
         &Statement::NumericFor(ref value) => emit_numeric_for(w, value)?,
+        &Statement::GenericFor(ref value) => emit_generic_for(w, value)?,
         &Statement::IfStatement(ref value) => emit_if_statement(w, value)?,
         &Statement::WhileLoop(ref value) => emit_while_loop(w, value)?,
         &Statement::RepeatLoop(ref value) => emit_repeat_loop(w, value)?,
@@ -45,6 +46,12 @@ fn emit_function_call<'a>(w: &mut Write, _function_call: &FunctionCall<'a>) -> f
 
 fn emit_numeric_for<'a>(w: &mut Write, _numeric_for: &NumericFor<'a>) -> fmt::Result {
     write!(w, "numeric for")?;
+
+    Ok(())
+}
+
+fn emit_generic_for<'a>(w: &mut Write, _generic_for: &GenericFor<'a>) -> fmt::Result {
+    write!(w, "generic for")?;
 
     Ok(())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -91,6 +91,7 @@ define_parser!(ParseStatement, Statement<'state>, |_, state| {
         ParseLocalAssignment => Statement::LocalAssignment,
         ParseFunctionCall => Statement::FunctionCall,
         ParseNumericFor => Statement::NumericFor,
+        ParseGenericFor => Statement::GenericFor,
         ParseIfStatement => Statement::IfStatement,
         ParseWhileLoop => Statement::WhileLoop,
         ParseRepeatLoop => Statement::RepeatLoop,
@@ -294,6 +295,23 @@ define_parser!(ParseNumericFor, NumericFor<'state>, |_, state| {
         start,
         end,
         step,
+        body,
+    }))
+});
+
+struct ParseGenericFor;
+define_parser!(ParseGenericFor, GenericFor<'state>, |_, state| {
+    let (state, _) = ParseSymbol(Symbol::For).parse(state)?;
+    let (state, vars) = DelimitedOneOrMore(ParseIdentifier, ParseSymbol(Symbol::Comma)).parse(state)?;
+    let (state, _) = ParseSymbol(Symbol::In).parse(state)?;
+    let (state, iterator) = ParseExpression.parse(state)?;
+    let (state, _) = ParseSymbol(Symbol::Do).parse(state)?;
+    let (state, body) = ParseChunk.parse(state)?;
+    let (state, _) = ParseSymbol(Symbol::End).parse(state)?;
+
+    Ok((state, GenericFor {
+        vars,
+        iterator,
         body,
     }))
 });

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -53,10 +53,15 @@ define_parser!(ParseIdentifier, Cow<'state, str>, |_, state: ParseState<'state>|
 });
 
 struct ParseSymbol(pub Symbol);
-define_parser!(ParseSymbol, (), |this: &ParseSymbol, state: ParseState<'state>| {
-    let (state, _) = ParseToken(TokenKind::Symbol(this.0)).parse(state)?;
+define_parser!(ParseSymbol, Symbol, |this: &ParseSymbol, state: ParseState<'state>| {
+    let (state, token) = ParseToken(TokenKind::Symbol(this.0)).parse(state)?;
+    let symbol = match token.kind {
+        TokenKind::Symbol(symbol) => symbol,
+        // The parsing will only succeed if we can eat a symbol.
+        _ => unreachable!()
+    };
 
-    Ok((state, ()))
+    Ok((state, symbol))
 });
 
 // chunk ::= {stat [`;´]} [laststat [`;´]]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -212,7 +212,14 @@ define_parser!(ParseValue, Expression<'state>, |_, state| {
         ParseFunctionCall => Expression::FunctionCall,
         ParseIdentifier => Expression::Name,
         ParseTableLiteral => Expression::Table,
+        ParseBoolean => Expression::Bool,
     })
+});
+
+struct ParseBoolean;
+define_parser!(ParseBoolean, bool, |_, state| {
+    let (state, matched) = Or(vec![ ParseSymbol(Symbol::True), ParseSymbol(Symbol::False) ]).parse(state)?;
+    Ok((state, matched == Symbol::True))
 });
 
 // local namelist [`=´ explist]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -304,14 +304,14 @@ define_parser!(ParseGenericFor, GenericFor<'state>, |_, state| {
     let (state, _) = ParseSymbol(Symbol::For).parse(state)?;
     let (state, vars) = DelimitedOneOrMore(ParseIdentifier, ParseSymbol(Symbol::Comma)).parse(state)?;
     let (state, _) = ParseSymbol(Symbol::In).parse(state)?;
-    let (state, iterator) = ParseExpression.parse(state)?;
+    let (state, item_source) = DelimitedOneOrMore(ParseExpression, ParseSymbol(Symbol::Comma)).parse(state)?;
     let (state, _) = ParseSymbol(Symbol::Do).parse(state)?;
     let (state, body) = ParseChunk.parse(state)?;
     let (state, _) = ParseSymbol(Symbol::End).parse(state)?;
 
     Ok((state, GenericFor {
         vars,
-        iterator,
+        item_source,
         body,
     }))
 });

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -213,6 +213,8 @@ define_parser!(ParseValue, Expression<'state>, |_, state| {
         ParseIdentifier => Expression::Name,
         ParseTableLiteral => Expression::Table,
         ParseBoolean => Expression::Bool,
+        // Hack: parse_first_of! cannot handle unit values
+        ParseNil => |_| Expression::Nil,
     })
 });
 
@@ -220,6 +222,12 @@ struct ParseBoolean;
 define_parser!(ParseBoolean, bool, |_, state| {
     let (state, matched) = Or(vec![ ParseSymbol(Symbol::True), ParseSymbol(Symbol::False) ]).parse(state)?;
     Ok((state, matched == Symbol::True))
+});
+
+struct ParseNil;
+define_parser!(ParseNil, (), |_, state| {
+    let (state, _) = ParseSymbol(Symbol::Nil).parse(state)?;
+    Ok((state, ()))
 });
 
 // local namelist [`=´ explist]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -221,7 +221,7 @@ define_parser!(ParseValue, Expression<'state>, |_, state| {
 
 struct ParseBoolean;
 define_parser!(ParseBoolean, bool, |_, state| {
-    let (state, matched) = Or(vec![ ParseSymbol(Symbol::True), ParseSymbol(Symbol::False) ]).parse(state)?;
+    let (state, matched) = Or(&[ ParseSymbol(Symbol::True), ParseSymbol(Symbol::False) ]).parse(state)?;
     Ok((state, matched == Symbol::True))
 });
 
@@ -441,7 +441,7 @@ define_parser!(ParseTableValue, (Option<TableKey<'state>>, Expression<'state>), 
 struct ParseTableLiteral;
 define_parser!(ParseTableLiteral, TableLiteral<'state>, |_, state| {
     let (state, _) = ParseSymbol(Symbol::LeftBrace).parse(state)?;
-    let (state, items) = DelimitedZeroOrMore(ParseTableValue, Or(vec![ ParseSymbol(Symbol::Comma), ParseSymbol(Symbol::Semicolon) ]), true).parse(state)?;
+    let (state, items) = DelimitedZeroOrMore(ParseTableValue, Or(&[ ParseSymbol(Symbol::Comma), ParseSymbol(Symbol::Semicolon) ]), true).parse(state)?;
     let (state, _) = ParseSymbol(Symbol::RightBrace).parse(state)?;
     Ok((state, TableLiteral {
         items

--- a/src/parser_core.rs
+++ b/src/parser_core.rs
@@ -50,7 +50,7 @@ pub trait Parser<'a> {
 
 #[macro_export]
 macro_rules! parse_first_of {
-    ($state: ident, { $( $parser: expr => $constructor: path ),* $(,)* }) => (
+    ($state: ident, { $( $parser: expr => $constructor: expr ),* $(,)* }) => (
         {
             $(
                 match $parser.parse($state) {

--- a/src/parser_core.rs
+++ b/src/parser_core.rs
@@ -207,13 +207,13 @@ impl<'a, ItemParser: Parser<'a>> Parser<'a> for Optional<ItemParser> {
     }
 }
 
-pub struct Or<InnerParser>(pub Vec<InnerParser>);
+pub struct Or<'a, InnerParser: 'a>(pub &'a [InnerParser]);
 
-impl<'a, InnerParser: Parser<'a>> Parser<'a> for Or<InnerParser> {
+impl<'a, InnerParser: Parser<'a>> Parser<'a> for Or<'a, InnerParser> {
     type Item = InnerParser::Item;
 
     fn parse(&self, state: ParseState<'a>) -> Result<(ParseState<'a>, Self::Item), ParseAbort> {
-        for parser in &self.0 {
+        for parser in self.0 {
             match parser.parse(state) {
                 Ok((new_state, matched_value)) => return Ok((new_state, matched_value)),
                 Err(ParseAbort::NoMatch) => (),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -35,6 +35,7 @@ pub enum Symbol {
     Repeat,
     Until,
     For,
+    In,
     Then,
     Do,
     Else,
@@ -76,6 +77,7 @@ impl Symbol {
             Symbol::Repeat => "repeat",
             Symbol::Until => "until",
             Symbol::For => "for",
+            Symbol::In => "in",
             Symbol::Then => "then",
             Symbol::Do => "do",
             Symbol::Else => "else",
@@ -187,6 +189,7 @@ lazy_static! {
         Symbol::Local, Symbol::Function,
         Symbol::If, Symbol::While, Symbol::Repeat, Symbol::Until, Symbol::For,
         Symbol::Then, Symbol::Do, Symbol::Else, Symbol::ElseIf, Symbol::End,
+        Symbol::In,
         Symbol::True, Symbol::False, Symbol::Nil,
         Symbol::Not,
     ];


### PR DESCRIPTION
* Boolean literal parsing
* `nil` parsing
* `ParseSymbol` now returns the symbol it ate; primarily useful for `Or` where you don't necessarily know what symbol you've parsed
* Generic for loop parsing
* `parse_first_of!` now accepts an `expr`, not just a `path`. This is a patch for an ugly hack:
  ```rust
  // Hack: parse_first_of! cannot handle unit values
  ParseNil => |_| Expression::Nil,
  ```